### PR TITLE
Fixed issue with Magento 1.8.1.0

### DIFF
--- a/app/code/community/Quadra/Atos/controllers/PaymentController.php
+++ b/app/code/community/Quadra/Atos/controllers/PaymentController.php
@@ -249,12 +249,12 @@ class Quadra_Atos_PaymentController extends Mage_Core_Controller_Front_Action {
                     $message .= '<br /><br />' . $this->getApiResponse()->describeResponse($response['hash']);
                     // Update state and status order
                     $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, Quadra_Atos_Model_Config::STATUS_ACCEPTED, $message);
+                    // Save order
+                    $order->save();
                     // Send confirmation email
                     if (!$order->getEmailSent()) {
                         $order->sendNewOrderEmail();
                     }
-                    // Save order
-                    $order->save();
                 }
                 break;
             // Rejected payment


### PR DESCRIPTION
... on payment notifications the order state
(and other changes) are not changed in Magento
1.8.1.0 because `sendNewOrderEmail()` will reload
all data in the `$order` object

See quadra-informatique/Magento-Module-Cybermut#2
