### PR TITLE
Fix inexisting tables that does not seem to be useful

### DIFF
--- a/app/code/community/Quadra/Atos/sql/atos_setup/mysql4-upgrade-2.0.5-2.0.6.php
+++ b/app/code/community/Quadra/Atos/sql/atos_setup/mysql4-upgrade-2.0.5-2.0.6.php
@@ -21,7 +21,7 @@ $installer->startSetup();
 
 $installer->run("
 
-CREATE TABLE IF NOT EXISTS `{$installer->getTable('atos/log_request')}` (
+CREATE TABLE IF NOT EXISTS `atos/log_request` (
   `entity_id` int(10) unsigned NOT NULL auto_increment,
   `order_id` varchar(50) NOT NULL ,
   `send_date` timestamp NOT NULL default CURRENT_TIMESTAMP,
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS `{$installer->getTable('atos/log_request')}` (
   PRIMARY KEY (`entity_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE IF NOT EXISTS `{$installer->getTable('atos/log_response')}` (
+CREATE TABLE IF NOT EXISTS `atos/log_response` (
   `entity_id` int(10) unsigned NOT NULL auto_increment,
   `transaction_id` varchar(50) NOT NULL,
   `authorisation_id` varchar(50) NOT NULL,


### PR DESCRIPTION
... but break the installation

We have not found why this setup was here and had to prevent calling `getTable` which threw errors on an old installation (migrating from `Mage_Atos`).
