### PR TITLE
Made the admin configuration actually useful for administrators

### DIFF
--- a/app/code/community/Quadra/Atos/controllers/PaymentController.php
+++ b/app/code/community/Quadra/Atos/controllers/PaymentController.php
@@ -248,7 +248,8 @@ class Quadra_Atos_PaymentController extends Mage_Core_Controller_Front_Action {
                     $message = $this->__('Payment accepted by Sips');
                     $message .= '<br /><br />' . $this->getApiResponse()->describeResponse($response['hash']);
                     // Update state and status order
-                    $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, Quadra_Atos_Model_Config::STATUS_ACCEPTED, $message);
+                    $acceptedStatus = $this->getMethodInstance()->getConfig()->getAcceptedStatus();
+                    $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, $acceptedStatus, $message);
                     // Send confirmation email
                     if (!$order->getEmailSent()) {
                         $order->sendNewOrderEmail();

--- a/app/code/community/Quadra/Atos/etc/system.xml
+++ b/app/code/community/Quadra/Atos/etc/system.xml
@@ -285,7 +285,7 @@
                         <order_status translate="label">
                             <label>New Order Status</label>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_order_status_new</source_model>
+                            <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -401,7 +401,7 @@
                         <order_status translate="label">
                             <label>New Order Status</label>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_order_status_new</source_model>
+                            <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -508,7 +508,7 @@
                         <order_status translate="label">
                             <label>New Order Status</label>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_order_status_new</source_model>
+                            <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -596,7 +596,7 @@
                         <order_status translate="label">
                             <label>New Order Status</label>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_order_status_new</source_model>
+                            <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
                             <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
... the extension will now use the configured order status upon
successful payments, defaulting with the sips processing status
as before